### PR TITLE
Enable Maven caching in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
+          cache: maven
 
       - run: mvn -B clean verify


### PR DESCRIPTION
## Description 

Add Maven caching to CI workflow for faster builds.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor

## Checklist

- [ ] Documentation updated
