### PR TITLE
fix: add jackson-databind to infrastructure for Hibernate JSON support

### DIFF
--- a/backend/food-quiz-infrastructure/pom.xml
+++ b/backend/food-quiz-infrastructure/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.11</version>

--- a/backend/food-quiz-infrastructure/src/test/java/com/guinardsolutions/foodquiz/infrastructure/InfrastructureTestApplication.java
+++ b/backend/food-quiz-infrastructure/src/test/java/com/guinardsolutions/foodquiz/infrastructure/InfrastructureTestApplication.java
@@ -1,0 +1,9 @@
+package com.guinardsolutions.foodquiz.infrastructure;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+class InfrastructureTestApplication {
+}

--- a/backend/food-quiz-infrastructure/src/test/java/com/guinardsolutions/foodquiz/infrastructure/entity/ChoiceQuestionEntityJpaTests.java
+++ b/backend/food-quiz-infrastructure/src/test/java/com/guinardsolutions/foodquiz/infrastructure/entity/ChoiceQuestionEntityJpaTests.java
@@ -1,0 +1,52 @@
+package com.guinardsolutions.foodquiz.infrastructure.entity;
+
+import com.guinardsolutions.foodquiz.infrastructure.repository.SpringDataQuestionRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(properties = {
+        "spring.test.database.replace=NONE",
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+class ChoiceQuestionEntityJpaTests {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private SpringDataQuestionRepository repository;
+
+    @Test
+    void should_persist_and_reload_json_fields() {
+        var entity = new ChoiceQuestionEntity(
+                null, "Quelle est la bonne portion ?",
+                "https://img.example.com/pomme.jpg", "Pomme", "1 portion standard",
+                List.of("100g", "150g", "200g"), "150g",
+                Map.of("Banane", 120, "Pain blanc", 30),
+                "Modéré"
+        );
+
+        repository.save(entity);
+        entityManager.flush();
+        entityManager.clear();
+
+        var saved = (ChoiceQuestionEntity) repository.findById(entity.getId()).orElseThrow();
+
+        assertThat(saved.getProposedAnswer()).containsExactlyInAnyOrder("100g", "150g", "200g");
+        assertThat(saved.getEquivalents())
+                .containsEntry("Banane", 120)
+                .containsEntry("Pain blanc", 30);
+    }
+}


### PR DESCRIPTION
## Summary

- Add explicit `jackson-databind` dependency to `food-quiz-infrastructure/pom.xml` — Hibernate 6+ requires Jackson on the classpath to initialize its `JsonFormatMapper` when processing `@JdbcTypeCode(SqlTypes.JSON)` fields (`proposedAnswer`, `equivalents` on `ChoiceQuestionEntity`)
- Add `@DataJpaTest` (`ChoiceQuestionEntityJpaTests`) that persists and reloads JSON fields — without `jackson-databind`, Hibernate fails at context startup and this test turns red before any assertion runs
- Add `InfrastructureTestApplication` (`@SpringBootConfiguration`) in test sources so `@DataJpaTest` can bootstrap without a `@SpringBootApplication` in this module

## Root cause

In Spring Boot 4.x, `spring-boot-starter-webmvc` (declared in `food-quiz-api`) no longer pulls Jackson transitively the way `spring-boot-starter-web` did in 3.x. The infrastructure module had no direct Jackson dependency, so Hibernate could not find a `FormatMapper` for JSON types at runtime.

CI tests were green because `JpaQuizRepositoryTests` uses pure Mockito — no Spring/Hibernate context is ever loaded, so the missing dependency was invisible until production.

## Test plan

- [ ] `mvn -pl food-quiz-infrastructure --also-make test` → 3 tests pass including the new `@DataJpaTest`
- [ ] `mvn clean verify` → full build passes (47 tests, 0 failures)
- [ ] `GET /quiz/start` no longer throws `HibernateException: Could not find a FormatMapper`

🤖 Generated with [Claude Code](https://claude.com/claude-code)